### PR TITLE
Extract artist badge for YouTube channels

### DIFF
--- a/play-dl/YouTube/classes/Channel.ts
+++ b/play-dl/YouTube/classes/Channel.ts
@@ -9,6 +9,7 @@ export interface ChannelIconInterface {
 export class YouTubeChannel {
     name?: string;
     verified?: boolean;
+    artist?: boolean;
     id?: string;
     type: 'video' | 'playlist' | 'channel';
     url?: string;
@@ -26,6 +27,7 @@ export class YouTubeChannel {
 
         this.name = data.name || null;
         this.verified = !!data.verified || false;
+        this.artist = !!data.artist || false;
         this.id = data.id || null;
         this.url = data.url || null;
         this.icon = data.icon || { url: null, width: 0, height: 0 };
@@ -52,6 +54,7 @@ export class YouTubeChannel {
         return {
             name: this.name,
             verified: this.verified,
+            artist: this.artist,
             id: this.id,
             url: this.url,
             iconURL: this.iconURL(),

--- a/play-dl/YouTube/utils/extractor.ts
+++ b/play-dl/YouTube/utils/extractor.ts
@@ -135,7 +135,8 @@ export async function video_basic_info(url: string, options: InfoOptions = {}) {
             name: vid.author,
             id: vid.channelId,
             url: `https://www.youtube.com/channel/${vid.channelId}`,
-            verified: Boolean(badge?.metadataBadgeRenderer?.style?.toLowerCase().includes('verified'))
+            verified: Boolean(badge?.metadataBadgeRenderer?.style?.toLowerCase().includes('verified')),
+            artist: Boolean(badge?.metadataBadgeRenderer?.style?.toLowerCase().includes('artist'))
         },
         views: vid.viewCount,
         tags: vid.keywords,

--- a/play-dl/YouTube/utils/parser.ts
+++ b/play-dl/YouTube/utils/parser.ts
@@ -98,6 +98,7 @@ export function parseChannel(data?: any): YouTubeChannel {
         },
         url: url,
         verified: Boolean(badge?.metadataBadgeRenderer?.style?.toLowerCase().includes('verified')),
+        artist: Boolean(badge?.metadataBadgeRenderer?.style?.toLowerCase().includes('artist')),
         subscribers: data.channelRenderer.subscriberCountText?.simpleText
             ? data.channelRenderer.subscriberCountText.simpleText
             : '0 subscribers'
@@ -141,7 +142,8 @@ export function parseVideo(data?: any): YouTubeVideo {
                 height: data.videoRenderer.channelThumbnailSupportedRenderers.channelThumbnailWithLinkRenderer.thumbnail
                     .thumbnails[0].height
             },
-            verified: Boolean(badge?.metadataBadgeRenderer?.style?.toLowerCase().includes('verified'))
+            verified: Boolean(badge?.metadataBadgeRenderer?.style?.toLowerCase().includes('verified')),
+            artist: Boolean(badge?.metadataBadgeRenderer?.style?.toLowerCase().includes('artist'))
         },
         uploadedAt: data.videoRenderer.publishedTimeText?.simpleText ?? null,
         views: data.videoRenderer.viewCountText?.simpleText?.replace(/[^0-9]/g, '') ?? 0,


### PR DESCRIPTION
Verified artists have a music note instead of a tick (checkmark) on their channel. This pull request adds a new artist property to YouTube channels, that is true if the channel has the artist badge (music note).