### PR TITLE
Improve Deezer share link handling

### DIFF
--- a/docs/Deezer/README.md
+++ b/docs/Deezer/README.md
@@ -18,7 +18,7 @@ console.log(data.type); // Console logs the type of data that you got.
 
 _This checks that given url is Deezer url or not._
 
-**Returns :** `track` | `album` | `playlist` | `search` | `share` | `false`
+**Returns :** `track` | `album` | `playlist` | `search` | `false`
 
 ```js
 let check = dz_validate(url)
@@ -26,8 +26,6 @@ let check = dz_validate(url)
 if(!check) // Invalid Deezer URL
 
 if(check === 'track') // Deezer Track URL
-
-if(check === 'share') // Deezer Share URL
 
 if(check === "search") // Given term is a search query. Search it somewhere.
 ```
@@ -52,18 +50,6 @@ const results = await dz_search(query, {
     type: 'track',
     fuzzy: false
 }); // Returns an array with one track, using exact matching
-```
-
-## Resolving a share URL
-
-### dz_resolve_share_url(url: `string`)
-
-_Resolves a Deezer share link (deezer.page.link) returning the deezer.com URL._
-
-**Returns :** `string` the resolved URL. Warning the returned URL might not be a track, album or playlist URL.
-
-```js
-const resolvedURL = await dz_resolve_share_url(url);
 ```
 
 ## Classes [ Returned by `deezer(url)` function ]

--- a/docs/README.md
+++ b/docs/README.md
@@ -12,7 +12,7 @@ For source specific commands :-
 
 _This checks all type of urls that are supported by play-dl._
 
-**Returns :** `so_playlist` | `so_track` | `sp_track` | `sp_album` | `sp_playlist` | `dz_track` | `dz_playlist` | `dz_album` | `dz_share` | `yt_video` | `yt_playlist` | `search` | `false`
+**Returns :** `so_playlist` | `so_track` | `sp_track` | `sp_album` | `sp_playlist` | `dz_track` | `dz_playlist` | `dz_album` | `yt_video` | `yt_playlist` | `search` | `false`
 
 `so` = **SoundCloud**
 

--- a/play-dl/Request/index.ts
+++ b/play-dl/Request/index.ts
@@ -127,11 +127,19 @@ export function request_resolve_redirect(url: string): Promise<string> {
             return;
         }
         const statusCode = Number(res.statusCode);
-        if (statusCode >= 300 && statusCode < 400) {
-            const resolved = await request_resolve_redirect(res.headers.location as string);
+        if (statusCode < 300) {
+            resolve(url);
+        } else if (statusCode < 400) {
+            const resolved = await request_resolve_redirect(res.headers.location as string).catch((err) => err);
+
+            if (res instanceof Error) {
+                reject(res);
+                return;
+            }
+
             resolve(resolved);
         } else {
-            resolve(url);
+            reject(new Error(`${res.statusCode}: ${res.statusMessage}, ${url}`));
         }
     });
 }

--- a/play-dl/index.ts
+++ b/play-dl/index.ts
@@ -10,7 +10,7 @@ export {
 } from './YouTube';
 export { spotify, sp_validate, refreshToken, is_expired, Spotify } from './Spotify';
 export { soundcloud, so_validate, SoundCloud, SoundCloudStream, getFreeClientID } from './SoundCloud';
-export { deezer, dz_validate, dz_search, dz_resolve_share_url, Deezer } from './Deezer';
+export { deezer, dz_validate, dz_search, Deezer } from './Deezer';
 export { setToken } from './token';
 
 enum AudioPlayerStatus {
@@ -123,7 +123,6 @@ export async function validate(
     | 'dz_track'
     | 'dz_playlist'
     | 'dz_album'
-    | 'dz_share'
     | 'yt_video'
     | 'yt_playlist'
     | 'search'
@@ -138,8 +137,8 @@ export async function validate(
         check = await so_validate(url);
         return check !== false ? (('so_' + check) as 'so_playlist' | 'so_track') : false;
     } else if (url.indexOf('deezer') !== -1) {
-        check = dz_validate(url);
-        return check !== false ? (('dz_' + check) as 'dz_track' | 'dz_playlist' | 'dz_album' | 'dz_share') : false;
+        check = await dz_validate(url);
+        return check !== false ? (('dz_' + check) as 'dz_track' | 'dz_playlist' | 'dz_album') : false;
     } else {
         check = yt_validate(url);
         return check !== false ? (('yt_' + check) as 'yt_video' | 'yt_playlist') : false;


### PR DESCRIPTION
dz_validate and validate will now resolve Deezer share links instead of returning 'share'.

This pull request REMOVES the `dz_resolve_share_url` function as it's no longer needed, which may break peoples code if they were using it, please mention it in the release notes.