### PR TITLE
Add Deezer advanced track search

### DIFF
--- a/docs/Deezer/README.md
+++ b/docs/Deezer/README.md
@@ -52,6 +52,32 @@ const results = await dz_search(query, {
 }); // Returns an array with one track, using exact matching
 ```
 
+### dz_advanced_track_search(options: `DeezerAdvancedSearchOptions`)
+
+_Searches Deezer for tracks using the specified metadata._
+
+**Returns :** `DeezerTrack[]` an array of tracks
+
+#### `DeezerAdvancedSearchOptions`
+
+-   **limit?** `number` The maximum number of results to return, maximum `100`, defaults to `10`.
+-   **artist?** `string` The name of the artist
+-   **album?** `string` The title of the album
+-   **title?** `string` The title of the track
+-   **label?** `string` The label that released the track
+-   **minDurationInSec?** `number` The minimum duration in seconds
+-   **maxDurationInSec?** `number` The maximum duration in seconds
+-   **minBpm?** `number` The minimum BPM
+-   **maxBpm?** `number` The minimum BPM
+
+```js
+const results = await dz_advanced_track_search({
+    limit: 1,
+    artist: 'Rick Astley',
+    title: 'Never Gonna Give You Up'
+}); // Returns an array with one track
+```
+
 ## Classes [ Returned by `deezer(url)` function ]
 
 ### DeezerTrack

--- a/play-dl/index.ts
+++ b/play-dl/index.ts
@@ -10,7 +10,7 @@ export {
 } from './YouTube';
 export { spotify, sp_validate, refreshToken, is_expired, Spotify } from './Spotify';
 export { soundcloud, so_validate, SoundCloud, SoundCloudStream, getFreeClientID } from './SoundCloud';
-export { deezer, dz_validate, dz_search, Deezer } from './Deezer';
+export { deezer, dz_validate, dz_search, dz_advanced_track_search, Deezer } from './Deezer';
 export { setToken } from './token';
 
 enum AudioPlayerStatus {


### PR DESCRIPTION
The pull request adds a function to use Deezer's advanced track search. This is differnent from the normal search because instead of a single query that gets matched to multiple properties, you can specify multiple bits of metadata to get more exact results.

Please merge #151 first because there are likely to be conflicts between the two pull requests.