### PR TITLE
Fix: YT unlisted info extraction

### DIFF
--- a/play-dl/YouTube/utils/extractor.ts
+++ b/play-dl/YouTube/utils/extractor.ts
@@ -96,12 +96,12 @@ export async function video_basic_info(url: string, options: InfoOptions = {}) {
     const player_data = body
         .split('var ytInitialPlayerResponse = ')?.[1]
         ?.split(';</script>')[0]
-        .split(/; (var|const|let)/)[0];
+        .split(/;\s*(var|const|let)/)[0];
     if (!player_data) throw new Error('Initial Player Response Data is undefined.');
     const initial_data = body
         .split('var ytInitialData = ')?.[1]
         ?.split(';</script>')[0]
-        .split(/; (var|const|let)/)[0];
+        .split(/;\s*(var|const|let)/)[0];
     if (!initial_data) throw new Error('Initial Response Data is undefined.');
     const player_response = JSON.parse(player_data);
     const initial_response = JSON.parse(initial_data);


### PR DESCRIPTION
I'm unsure why this is the noticeable difference between unlisted and public videos, but that's on YouTube's end anyways
/shrug