### PR TITLE
Ensure that the favicon gets shown in the docs

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,17 +1,18 @@
 {
   "name": "play-dl",
-  "version": "1.3.0",
+  "version": "1.3.5",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "play-dl",
-      "version": "1.3.0",
+      "version": "1.3.5",
       "license": "GPL-3.0",
       "devDependencies": {
         "@types/node": "^16.9.4",
         "prettier": "^2.3.1",
         "typedoc": "^0.22.9",
+        "typedoc-plugin-extras": "^2.2.1",
         "typedoc-plugin-missing-exports": "^0.22.4",
         "typescript": "^4.4.4"
       },
@@ -204,6 +205,15 @@
       },
       "peerDependencies": {
         "typescript": "4.0.x || 4.1.x || 4.2.x || 4.3.x || 4.4.x"
+      }
+    },
+    "node_modules/typedoc-plugin-extras": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/typedoc-plugin-extras/-/typedoc-plugin-extras-2.2.1.tgz",
+      "integrity": "sha512-WOIB587S+Q+DojCFB89QVLT4NGmC1tjaHDunnZ20Z2eEEe6w7AdYtS5oqO6S6v1VPCzj4WehGbayK7TbnCzIMg==",
+      "dev": true,
+      "peerDependencies": {
+        "typedoc": "0.22.x"
       }
     },
     "node_modules/typedoc-plugin-missing-exports": {
@@ -401,6 +411,13 @@
         "minimatch": "^3.0.4",
         "shiki": "^0.9.12"
       }
+    },
+    "typedoc-plugin-extras": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/typedoc-plugin-extras/-/typedoc-plugin-extras-2.2.1.tgz",
+      "integrity": "sha512-WOIB587S+Q+DojCFB89QVLT4NGmC1tjaHDunnZ20Z2eEEe6w7AdYtS5oqO6S6v1VPCzj4WehGbayK7TbnCzIMg==",
+      "dev": true,
+      "requires": {}
     },
     "typedoc-plugin-missing-exports": {
       "version": "0.22.4",

--- a/package.json
+++ b/package.json
@@ -44,6 +44,7 @@
     "prettier": "^2.3.1",
     "typedoc": "^0.22.9",
     "typedoc-plugin-missing-exports": "^0.22.4",
-    "typescript": "^4.4.4"
+    "typescript": "^4.4.4",
+    "typedoc-plugin-extras": "^2.2.1"
   }
 }

--- a/typedoc.json
+++ b/typedoc.json
@@ -1,5 +1,6 @@
 {
     "entryPoints": ["./play-dl"],
-	"plugin" : "typedoc-plugin-missing-exports",
-    "out": "docs/docs"
+    "plugin" : [ "typedoc-plugin-missing-exports", "typedoc-plugin-extras" ],
+    "out": "docs/docs",
+    "favicon": "./docs/favicon.ico"
 }


### PR DESCRIPTION
As it currently is the favicon doesn't show up on the docs website. This pull request adds the `typedoc-plugin-extras` typedoc plugin, which copies the favicon.ico into the same directory as the docs and inserts `<link rel="icon" href="path/to/favicon.ico" />` into each page to ensure it is shown for all pages.