### PR TITLE
Extract YouTube video ratings

### DIFF
--- a/play-dl/YouTube/classes/Video.ts
+++ b/play-dl/YouTube/classes/Video.ts
@@ -154,8 +154,8 @@ export class YouTubeVideo {
         this.views = parseInt(data.views) || 0;
         this.thumbnail = data.thumbnail || {};
         this.channel = new YouTubeChannel(data.channel) || {};
-        this.likes = (data.ratings?.likes as number) || 0;
-        this.dislikes = data.ratings?.dislikes || 0;
+        this.likes = data.likes || 0;
+        this.dislikes = data.dislikes || 0;
         this.live = !!data.live;
         this.private = !!data.private;
         this.tags = data.tags || [];

--- a/play-dl/YouTube/utils/extractor.ts
+++ b/play-dl/YouTube/utils/extractor.ts
@@ -162,6 +162,10 @@ export async function video_basic_info(url: string, options: InfoOptions = {}): 
     const format = [];
     const vid = player_response.videoDetails;
     const microformat = player_response.microformat.playerMicroformatRenderer;
+    const ratingButtons =
+        initial_response.contents.twoColumnWatchNextResults.results.results.contents.find(
+            (content: any) => content.videoPrimaryInfoRenderer
+        )?.videoPrimaryInfoRenderer.videoActions.menuRenderer.topLevelButtons ?? [];
     const video_details = new YouTubeVideo({
         id: vid.videoId,
         url: `https://www.youtube.com/watch?v=${vid.videoId}`,
@@ -182,6 +186,16 @@ export async function video_basic_info(url: string, options: InfoOptions = {}): 
         views: vid.viewCount,
         tags: vid.keywords,
         averageRating: vid.averageRating,
+        likes: parseInt(
+            ratingButtons
+                .find((button: any) => button.toggleButtonRenderer.defaultIcon.iconType === 'LIKE')
+                ?.toggleButtonRenderer.defaultText.accessibility?.accessibilityData.label.replace(/\D+/g, '') ?? 0
+        ),
+        dislikes: parseInt(
+            ratingButtons
+                .find((button: any) => button.toggleButtonRenderer.defaultIcon.iconType === 'DISLIKE')
+                ?.toggleButtonRenderer.defaultText.accessibility?.accessibilityData.label.replace(/\D+/g, '') ?? 0
+        ),
         live: vid.isLiveContent,
         private: vid.isPrivate
     });


### PR DESCRIPTION
Extracts the YouTube ratings if available and defaults to 0 if they are missing. For most videos, the dislike count will be 0, as YouTube is removing the ability to see the dislikes (not good but nothing we can do about it).

In the future it might make sense to add support for one of those third party APIs that are using different metrics to approximate what the dislike count could be, it won't be exact but it's better than nothing, although this should be in function in the YouTubeVideo class (maybe `fetchApproximateDislikes`), so that the people that it doesn't slow down the `video_basic_info` function for people that don't need the dislikes.