### PR TITLE
Add an error message for YouTube's captcha page

### DIFF
--- a/play-dl/YouTube/utils/extractor.ts
+++ b/play-dl/YouTube/utils/extractor.ts
@@ -132,7 +132,13 @@ export async function video_basic_info(url: string, options: InfoOptions = {}): 
         .split('var ytInitialPlayerResponse = ')?.[1]
         ?.split(';</script>')[0]
         .split(/;\s*(var|const|let)/)[0];
-    if (!player_data) throw new Error('Initial Player Response Data is undefined.');
+    if (!player_data) {
+        if (body.indexOf('Our systems have detected unusual traffic from your computer network.') !== -1) {
+            throw new Error('Captcha page: YouTube has detected that you are a bot!');
+        } else {
+            throw new Error('Initial Player Response Data is undefined.');
+        }
+    }
     const initial_data = body
         .split('var ytInitialData = ')?.[1]
         ?.split(';</script>')[0]


### PR DESCRIPTION
If YouTube thinks you are a bot, it will return a captcha page ("please select all road signs", etc.), as play-dl can't solve those, we should return an appropriate error.

![youtube-captcha](https://user-images.githubusercontent.com/48293849/143690096-df8f6c07-503a-42df-add1-08f8ca8617b8.png)