### PR TITLE
Optimise YouTube stream function

### DIFF
--- a/play-dl/YouTube/utils/cipher.ts
+++ b/play-dl/YouTube/utils/cipher.ts
@@ -101,7 +101,7 @@ function deciper_signature(tokens: string[], signature: string) {
         switch (token.slice(0, 2)) {
             case 'sw':
                 pos = parseInt(token.slice(2));
-                sig = swappositions(sig, pos);
+                swappositions(sig, pos);
                 break;
             case 'rv':
                 sig.reverse();
@@ -122,13 +122,11 @@ function deciper_signature(tokens: string[], signature: string) {
  * Function to swap positions in a array
  * @param array array
  * @param position position to switch with first element
- * @returns new array with swapped positions.
  */
 function swappositions(array: string[], position: number) {
     const first = array[0];
     array[0] = array[position];
     array[position] = first;
-    return array;
 }
 /**
  * Sets Download url with some extra parameter

--- a/play-dl/YouTube/utils/constants.ts
+++ b/play-dl/YouTube/utils/constants.ts
@@ -37,3 +37,10 @@ export interface InfoData {
     video_details: YouTubeVideo;
     related_videos: string[];
 }
+
+export interface StreamInfoData {
+    LiveStreamData: LiveStreamData;
+    html5player: string;
+    format: Partial<formatData>[];
+    video_details: Pick<YouTubeVideo, 'url' | 'durationInSec'>;
+}


### PR DESCRIPTION
This pull request optimises the flow for the `stream` function, instead of using the previous setup of `video_info` => `video_basic_info` => `decipher_info`, which extracts a lot of unneeded information that isn't needed for streaming, it introduces a dedicated `video_stream_info` which extracts only the necessary information. This is 2.7x faster (excluding network requests and deciphering) than `video_basic_info`.

Additionally this makes a minor change to the deciphering, as the swapping is done in-place (on the same array), assigning the array to the variable again is a superfluous operation. Passing an array (and other objects) to a function doesn't create a copy of the array, it just passes a reference pointing to original array.