### PR TITLE
Follow redirects properly when making requests

### DIFF
--- a/play-dl/Request/index.ts
+++ b/play-dl/Request/index.ts
@@ -48,14 +48,14 @@ function internalRequest(
             reject(res);
             return;
         }
-        if (res.headers && res.headers['set-cookie'] && cookies_added) {
-            cookieHeaders(res.headers['set-cookie']);
-        }
         if (Number(res.statusCode) >= 300 && Number(res.statusCode) < 400) {
             res = await internalRequest(res.headers.location as string, cookies_added, options);
         } else if (Number(res.statusCode) > 400) {
             reject(new Error(`Got ${res.statusCode} from the request`));
             return;
+        }
+        if (res.headers && res.headers['set-cookie'] && cookies_added) {
+            cookieHeaders(res.headers['set-cookie']);
         }
         resolve(res);
     });

--- a/tsup.config.json
+++ b/tsup.config.json
@@ -12,5 +12,6 @@
     "skipNodeModulesBundle": true,
     "sourcemap": true,
     "target": "es2021",
-    "splitting": false
+    "splitting": false,
+    "keepNames": true
 }


### PR DESCRIPTION
This pull request makes the `request` function properly follow redirects and handle errors, also removes the unused ProxyOpts interface.