### PR TITLE
1.8.2

### DIFF
--- a/play-dl/YouTube/stream.ts
+++ b/play-dl/YouTube/stream.ts
@@ -63,7 +63,7 @@ export async function stream_from_info(
     info: InfoData | StreamInfoData,
     options: StreamOptions = {}
 ): Promise<YouTubeStream> {
-    if (!info.format || info.format.length === 0)
+    if (info.format.length === 0)
         throw new Error('Upcoming and premiere videos that are not currently live cannot be streamed.');
 
     const final: any[] = [];


### PR DESCRIPTION
## Change Log :-

- [x] Added a property upcoming to `YouTubeVideo`, which will be undefined for normal or livestream videos and the premiere date if it is a premiere/upcoming video
- [x] `stream` and `stream_from_info` function throws error if video is premier.
- [x] Filtering premier videos can be done by
```ts
const videos = await (await playlist_info('url')).all_videos();

const filtered = videos.filter(v => !v.upcoming);
```
- [x] Added support to parse only audio formats in `decipher_info` function.