### PR TITLE
1.8.8

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "play-dl",
-  "version": "1.8.6",
+  "version": "1.8.7",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "play-dl",
-      "version": "1.8.6",
+      "version": "1.8.7",
       "license": "GPL-3.0",
       "dependencies": {
         "play-audio": "^0.5.2"

--- a/play-dl/YouTube/classes/Video.ts
+++ b/play-dl/YouTube/classes/Video.ts
@@ -120,6 +120,10 @@ export class YouTubeVideo {
      */
     uploadedAt?: string;
     /**
+     * YouTube Live Date
+     */
+    liveAt?: string;
+    /**
      * If the video is upcoming or a premiere that isn't currently live, this will contain the premiere date, for watch page playlists this will be true, it defaults to undefined
      */
     upcoming?: Date | true;
@@ -174,6 +178,7 @@ export class YouTubeVideo {
         this.durationRaw = data.duration_raw || '0:00';
         this.durationInSec = (data.duration < 0 ? 0 : data.duration) || 0;
         this.uploadedAt = data.uploadedAt || undefined;
+        this.liveAt = data.liveAt || undefined;
         this.upcoming = data.upcoming;
         this.views = parseInt(data.views) || 0;
         const thumbnails = [];

--- a/play-dl/YouTube/utils/extractor.ts
+++ b/play-dl/YouTube/utils/extractor.ts
@@ -244,6 +244,7 @@ export async function video_basic_info(url: string, options: InfoOptions = {}): 
         duration: Number(vid.lengthSeconds),
         duration_raw: parseSeconds(vid.lengthSeconds),
         uploadedAt: microformat.publishDate,
+        liveAt: microformat.liveBroadcastDetails?.startTimestamp,
         upcoming: upcomingDate,
         thumbnails: vid.thumbnail.thumbnails,
         channel: {


### PR DESCRIPTION
## Change Log :-

- [x] Added `liveAt` property in YouTube Video class. [ Tells when a livestream was started. ]