### PR TITLE
prevent null decoratedPlayerBarRenderer

### DIFF
--- a/play-dl/YouTube/utils/extractor.ts
+++ b/play-dl/YouTube/utils/extractor.ts
@@ -230,7 +230,7 @@ export async function video_basic_info(url: string, options: InfoOptions = {}): 
         });
     }
     const rawChapters =
-        initial_response.playerOverlays.playerOverlayRenderer.decoratedPlayerBarRenderer.decoratedPlayerBarRenderer.playerBar?.multiMarkersPlayerBarRenderer.markersMap.find(
+        initial_response.playerOverlays.playerOverlayRenderer.decoratedPlayerBarRenderer?.decoratedPlayerBarRenderer.playerBar?.multiMarkersPlayerBarRenderer.markersMap.find(
             (m: any) => m.key === 'DESCRIPTION_CHAPTERS'
         )?.value?.chapters;
     const chapters: VideoChapter[] = [];


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
the video's `decoratedPlayerBarRenderer` might be undefined sometimes when trying to call `video_info` or `video_basic_info` function

```js
{
  playerOverlayRenderer: {
    endScreen: { watchNextEndScreenRenderer: [Object] },
    autoplay: { playerOverlayAutoplayRenderer: [Object] },
    shareButton: { buttonRenderer: [Object] },
    addToMenu: { menuRenderer: [Object] },
    videoDetails: { playerOverlayVideoDetailsRenderer: [Object] },
    autonavToggle: { autoplaySwitchButtonRenderer: [Object] }
  }
}
```

I tried to print `playerOverlayRenderer` to check whether `decoratedPlayerBarRenderer` exist or not