### PR TITLE
Let playlist_info() use cookie

### DIFF
--- a/play-dl/YouTube/utils/extractor.ts
+++ b/play-dl/YouTube/utils/extractor.ts
@@ -521,7 +521,8 @@ export async function playlist_info(url: string, options: PlaylistOptions = {}):
     const body = await request(url_, {
         headers: {
             'accept-language': options.language || 'en-US;q=0.9'
-        }
+        },
+        cookie: true,
     });
     if (body.indexOf('Our systems have detected unusual traffic from your computer network.') !== -1)
         throw new Error('Captcha page: YouTube has detected that you are a bot!');


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
`playlist_info()` didn't use cookie when sending requests. This pull request lets `playlist_info()` use cookie when sending requests.
