### PR TITLE
Fix yt_validate stack overflow issue

### DIFF
--- a/play-dl/YouTube/utils/extractor.ts
+++ b/play-dl/YouTube/utils/extractor.ts
@@ -61,7 +61,7 @@ export function yt_validate(url: string): 'playlist' | 'video' | 'search' | fals
             else return 'search';
         }
     } else {
-        if (!url_.match(playlist_pattern)) return yt_validate(url_.replace(/(\?|\&)list=[^&]+/, ''));
+        if (!url_.match(playlist_pattern)) return yt_validate(url_.replace(/(\?|\&)list=[^&]*/, ''));
         else return 'playlist';
     }
 }


### PR DESCRIPTION
https://github.com/play-dl/play-dl/issues/304

yt_validate was recursing forever because the regex for removing
the 'list=xxxx' parameter was looking for 1 or more characters
after list=, rather than 0 or more, so removed nothing if
no value was provided.

e.g https://www.youtube.com/playlist?list=

This change makes the regex look for 0 or more chars after list=, rather than one or more.

Have tested this locally but would appreciate a second look before merging.

