### PR TITLE
Save the ISRC to `SpotifyTrack`

### DIFF
--- a/play-dl/Spotify/classes.ts
+++ b/play-dl/Spotify/classes.ts
@@ -86,6 +86,10 @@ export class SpotifyTrack {
      */
     id: string;
     /**
+     * Spotify Track ISRC
+     */
+    isrc: string;
+    /**
      * Spotify Track url
      */
     url: string;
@@ -124,6 +128,7 @@ export class SpotifyTrack {
     constructor(data: any) {
         this.name = data.name;
         this.id = data.id;
+        this.isrc = data.external_ids.isrc || '';
         this.type = 'track';
         this.url = data.external_urls.spotify;
         this.explicit = data.explicit;


### PR DESCRIPTION
Saves the **ISRC** (International Standard Recording Code) to a `SpotifyTrack`.\
Using the ISRC over the title + author to search on YouTube gives a more accurate track.

![image](https://user-images.githubusercontent.com/27646710/179410828-3d2e425a-2bfb-4709-84b4-5c6bd0f90103.png)