### PR TITLE
✅ | Command line tools

### DIFF
--- a/bin/cli.js
+++ b/bin/cli.js
@@ -1,0 +1,3 @@
+#! /usr/bin/env node
+const play = require('../dist/index.js')
+play.authorization()

--- a/instructions/README.md
+++ b/instructions/README.md
@@ -76,3 +76,28 @@ play.getFreeClientID().then((clientID) => {
     })
 })
 ```
+
+## CLI
+
+play-dl provide a CLI for authorization! Simply install play-dl as a Dev Dependency and create a script called `auth` with the value `playdl-auth`
+
+Run `npm run auth` or `yarn auth` in your shell
+
+##### Installing playdl as a Dev Dependency
+
+```bash
+npm install -D play-dl
+# or yarn
+yarn add -D play-dl
+```
+##### Creating a script in package.json
+
+Simply add this to package.json
+
+```json
+{
+    "scripts": {
+        "auth": "playdl-auth"
+    }
+}
+```

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "play-dl",
-  "version": "1.9.5",
+  "version": "1.9.6",
   "description": "YouTube, SoundCloud, Spotify, Deezer searching and streaming for discord-js bots",
   "main": "dist/index.js",
   "typings": "dist/index.d.ts",
@@ -52,5 +52,8 @@
   },
   "dependencies": {
     "play-audio": "^0.5.2"
+  },
+  "bin": {
+    "playdl-auth": "bin/cli.js"
   }
 }


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be **merged:****
Normally, play-dl use `play.authorization()` as a method for getting Spotify, YouTube or Soundcloud tokens. This will add a CLI tool to take care of that all in the cli.

Simply run
```bash
playdl-auth
```
