### PR TITLE
SimplifiedTrackObject from album does not have external_ids

### DIFF
--- a/play-dl/Spotify/classes.ts
+++ b/play-dl/Spotify/classes.ts
@@ -128,7 +128,7 @@ export class SpotifyTrack {
     constructor(data: any) {
         this.name = data.name;
         this.id = data.id;
-        this.isrc = data.external_ids.isrc || '';
+        this.isrc = data.external_ids?.isrc || '';
         this.type = 'track';
         this.url = data.external_urls.spotify;
         this.explicit = data.explicit;


### PR DESCRIPTION
Fixes an error which occurs when using play-dl.spotify() on an album URL due to the tracks not being the typical track, but a SimplifiedTrackObject, which does not have external_ids.