### PR TITLE
Stream, video details title value

### DIFF
--- a/play-dl/YouTube/utils/extractor.ts
+++ b/play-dl/YouTube/utils/extractor.ts
@@ -399,6 +399,7 @@ export async function video_stream_info(url: string, options: InfoOptions = {}):
     const html5player = `https://www.youtube.com${body.split('"jsUrl":"')[1].split('"')[0]}`;
     const duration = Number(player_response.videoDetails.lengthSeconds);
     const video_details = {
+        title: player_response.videoDetails.title,
         url: `https://www.youtube.com/watch?v=${player_response.videoDetails.videoId}`,
         durationInSec: (duration < 0 ? 0 : duration) || 0
     };


### PR DESCRIPTION
When you capture video details from another function, there is a waste of time. Wouldn't this method make more sense in terms of performance instead?