### PR TITLE
fix

### DIFF
--- a/play-dl/index.ts
+++ b/play-dl/index.ts
@@ -293,8 +293,14 @@ async function validate(
     const url_ = url.trim();
     if (!url_.startsWith('https')) return 'search';
     if (url_.indexOf('spotify') !== -1) {
-        check = sp_validate(url_);
-        return check !== false ? (('sp_' + check) as 'sp_track' | 'sp_album' | 'sp_playlist') : false;
+        try {
+            check = sp_validate(url_);
+            return check !== false ? (('sp_' + check) as 'sp_track' | 'sp_album' | 'sp_playlist') : false;
+        } catch(e)
+        {
+            return false;
+        }
+       
     } else if (url_.indexOf('soundcloud') !== -1) {
         check = await so_validate(url_);
         return check !== false ? (('so_' + check) as 'so_playlist' | 'so_track') : false;


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

```ts
public async Search(query: string)
    {
        const validate = await play.validate(query);
        switch(validate)
        {   
            case "yt_playlist":
            case "yt_video":
            case "search":
                console.log("Youtube Search")
                return this.QueryYoutube(query);
            case "sp_album":
            case "sp_playlist":
            case "sp_track":
                console.log("Spotify Search!");
                return this.QuerySpotify(query);
            case false:
            case "dz_album":
            case "dz_track":
            case "dz_playlist":
            case "so_playlist":
            case "so_track":
                return null;
        }
        ```
        My bot doesn't support soundcloud and I don't need to set a token. I verify the url and get an error like this.